### PR TITLE
Made package name valid & added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Don't upload the config!
+Bootcamp3/server/config/config.js
+
+# Don't upload the node modules
+Bootcamp3/node_modules

--- a/Bootcamp3/package.json
+++ b/Bootcamp3/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Bootcamp#3",
+  "name": "Bootcamp3",
   "version": "3.0.0",
   "description": "Routing server-side requests using ExpressJS",
   "main": "server.js",


### PR DESCRIPTION
In npm it is invalid to have hashtags in the package name.
This stops npm install from automatically installing all the needed packages.
Before this PR:
![Screenshot_20190930_151317](https://user-images.githubusercontent.com/20343235/65909147-f0bc1100-e395-11e9-8a85-44a01db39b14.png)
After this PR:
![Screenshot_20190930_151945](https://user-images.githubusercontent.com/20343235/65909158-f7e31f00-e395-11e9-9d41-4227c1092bf4.png)

I also noticed that there is no gitignore, so I added one to prevent people from accidentally uploading their config.js.
